### PR TITLE
ci: fixup: add ability for tests to retry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,9 @@
 stages: 
   - test
 
+default:
+    retry: 1
+
 ## YAML Anchors
 .build-core: &build-core
     - git clone https://github.com/flux-framework/flux-core


### PR DESCRIPTION
Problem: tests can error out due to timeouts and
sometimes will pass on a second try.

Solution: Using GitLab defaults, give each test
one retry if it fails before it reports a failing
pipeline. Source: https://docs.gitlab.com/ee/ci/yaml/#retry

Why now: `test_libterminus.t` has failed twice on quartz this week and succeeded the second time around on a retry. This is the log error message it gives back:

```
bash-4.4$ cat test_terminus.log
../../../config/tap-driver.sh: line 679: 1446343 Segmentation fault      "$@"
ERROR: test_terminus.t - missing test plan
ERROR: test_terminus.t - exited with status 139 (terminated by signal 11?)
```

Must be the TAP output getting truncated?