### PR TITLE
.gitlab: directory structure rework

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,71 +8,33 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
+include:
+  - local: '.gitlab/builds.gitlab-ci.yml'
+  - local: '.gitlab/machines.gitlab-ci.yml'
+
 stages: 
   - test
 
 default:
     retry: 1
 
-## YAML Anchors
-.build-core: &build-core
-    - git clone https://github.com/flux-framework/flux-core
-    - cd flux-core
-    - export FLUX_BUILD_DIR=$(pwd)
-    - lstopo --of xml >$(hostname).xml
-    - export FLUX_HWLOC_XMLFILE=$(pwd)/$(hostname).xml
-    - ./autogen.sh
-    - ./configure
-    - make -j 32
-    - cd ..
-
-## Reusable Scripts
-.standard-variables:
+.lc-variables:
     variables:
         LLNL_SERVICE_USER: fluxci
-        PYTHON: "/usr/bin/python3"
-        HWLOC_COMPONENTS: x86
-        debug: t
-        FLUX_TESTS_LOGFILE: t
         FF_ENABLE_JOB_CLEANUP: "false"
         CUSTOM_CI_BUILDS_DIR: "/usr/WS1/$$USER/gitlab-runner-builds-dir"
         # Note: the above will not work with /usr/workspace, you must specify WS1 or WS2
 
 .test-core:
-    extends: .standard-variables
+    extends: .lc-variables
+    variables:
+        PYTHON: "/usr/bin/python3"
+        debug: t
+        FLUX_TESTS_LOGFILE: t
     script:
-        - *build-core
+        - !reference ['.build-core', 'script']
         - cd $FLUX_BUILD_DIR
         - make -j 32 check
-
-## Machine Configurations
-.corona:
-    tags:
-        - corona
-        - batch
-    variables:
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 --setattr=system.bank=lc"
-
-.poodle:
-    tags:
-        - poodle
-        - batch
-    variables:
-        LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -p pdebug -N 1"
-
-.tioga:
-    tags:
-        - tioga
-        - batch
-    variables:
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1"
-
-.quartz:
-    tags:
-        - quartz
-        - batch
-    variables: 
-        LLNL_SLURM_SCHEDULER_PARAMETERS: "-p pdebug -N 1"
 
 ## Job Specifications
 corona-core-test:
@@ -98,4 +60,3 @@ quartz-core-test:
         - .test-core
         - .quartz
     stage: test
-

--- a/.gitlab/builds.gitlab-ci.yml
+++ b/.gitlab/builds.gitlab-ci.yml
@@ -1,0 +1,21 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+.build-core:
+  script:
+    - git clone https://github.com/flux-framework/flux-core
+    - cd flux-core
+    - export FLUX_BUILD_DIR=$(pwd)
+    - lstopo --of xml >$(hostname).xml
+    - export FLUX_HWLOC_XMLFILE=$(pwd)/$(hostname).xml
+    - ./autogen.sh
+    - ./configure
+    - make -j 32
+    - cd ..

--- a/.gitlab/machines.gitlab-ci.yml
+++ b/.gitlab/machines.gitlab-ci.yml
@@ -1,0 +1,42 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+## Machine Configurations
+.corona:
+    tags:
+        - corona
+        - batch
+    variables:
+        HWLOC_COMPONENTS: "x86"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 --setattr=system.bank=lc"
+
+.poodle:
+    tags:
+        - poodle
+        - batch
+    variables:
+        HWLOC_COMPONENTS: "x86"
+        LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -p pdebug -N 1"
+
+.tioga:
+    tags:
+        - tioga
+        - batch
+    variables:
+        HWLOC_COMPONENTS: "x86"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1"
+
+.quartz:
+    tags:
+        - quartz
+        - batch
+    variables: 
+        HWLOC_COMPONENTS: "x86"
+        LLNL_SLURM_SCHEDULER_PARAMETERS: "-p pdebug -N 1"


### PR DESCRIPTION
Problem: the .gitlab-ci.yml top-level file will become overgrown as we progress in the number of tests that we want to run on our framework repositories. Adding jobs, machines, and tests should be organized and easy in syntax/file structure.

Utilize YAML syntax and include statements to rework the files in a directory structure. Note that the use of `include` eliminates the functionality of YAML anchors [but reference tags are a good workaround](https://docs.gitlab.com/ee/ci/yaml/yaml_optimization.html#reference-tags ).