### PR TITLE
.github: add commit validator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+on: [pull_request, push, merge_group]
+name: ci
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  check-pr:
+    name: validate commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch origin main
+    - uses: flux-framework/pr-validator@master


### PR DESCRIPTION
.github: add commit validator

Problem: RFC 1 outlines specific requirements for framework
repositories. This includes directives about commit messages.
Sometimes, it's easy to forget about these requirements.

Add the PR validator workflow for this repository in GitHub, so
that every PR's commit messages will be checked. It's much easier
to comply with RFC 1 if an external tool is checking for commit
messages.