### PR TITLE
gitlab: update corona specification to use pdebug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,5 +78,5 @@ corona-mpi-test:
         - .test-core-mpi
         - .corona
     variables:
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "-N2"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "-N 2 -q pdebug"
     stage: test

--- a/.gitlab/machines.gitlab-ci.yml
+++ b/.gitlab/machines.gitlab-ci.yml
@@ -15,7 +15,7 @@
         - batch
     variables:
         HWLOC_COMPONENTS: "x86"
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 --setattr=system.bank=lc"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pdebug --setattr=bank=lc"
 
 .poodle:
     tags:
@@ -23,7 +23,7 @@
         - batch
     variables:
         HWLOC_COMPONENTS: "x86"
-        LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -p pdebug -N 1"
+        LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -N 1 -p pdebug"
 
 .tioga:
     tags:
@@ -31,7 +31,7 @@
         - batch
     variables:
         HWLOC_COMPONENTS: "x86"
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pdebug"
 
 .quartz:
     tags:
@@ -39,4 +39,4 @@
         - batch
     variables: 
         HWLOC_COMPONENTS: "x86"
-        LLNL_SLURM_SCHEDULER_PARAMETERS: "-p pdebug -N 1"
+        LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -p pdebug"


### PR DESCRIPTION
Oops. When adding the MPI testing, I forgot to add the option to allow these jobs to run in the `pdebug` queue. Because these jobs don't run during the business day, and are pretty quick (once the allocation is granted), that's the preferred queue as `pbatch` can get bogged down with nightly compute jobs. This is actually why corona is timing out more often than other machines, because I forgot to add it to the core test options as well.

Added `pdebug` for both MPI testing and normal core testing where it was missing. While I was at it, I reformatted options on some of the other machines to make them in consistent order for readability.

P.S. it's allowed to run CI jobs in `pdebug`, there's actually [an example](https://lc.llnl.gov/confluence/display/GITLAB/First+pipeline+with+LC+Gitlab+CI) on the GitLab CI confluence for LC that does just that. 