### PR TITLE
gitlab: add flux-pmix to CI testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,25 @@ default:
         - cd ${CORE_BUILD_DIR}
         - make -j $(nproc) check
 
+.test-pmix:
+    extends: .lc-variables
+    variables:
+        PYTHON: "/usr/bin/python3"
+        debug: t
+        FLUX_TESTS_LOGFILE: t
+    script:
+        - export FTC_DIRECTORY=$(pwd)
+        - !reference ['.build-core', 'script']
+        - export PKG_CONFIG_PATH=${CORE_INSTALL_PREFIX}/lib/pkgconfig:$(pkg-config --variable pc_path pkg-config)
+        - module load openmpi
+        - export PKG_CONFIG_PATH=$(dirname $(which mpicc))/../lib/pkgconfig:${PKG_CONFIG_PATH} 
+        - cd ${FTC_DIRECTORY}
+        - git clone https://github.com/flux-framework/flux-pmix
+        - cd flux-pmix
+        - ./autogen.sh
+        - ./configure
+        - make -j $(nproc) check
+
 .test-core-mpi:
     extends: .lc-variables
     variables: 
@@ -71,6 +90,12 @@ quartz-core-test:
     extends: 
         - .test-core
         - .quartz
+    stage: test
+
+corona-pmix-test:
+    extends:
+        - .test-pmix
+        - .corona
     stage: test
 
 corona-mpi-test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,8 +35,8 @@ default:
         - lstopo --of xml >$(hostname).xml
         - export FLUX_HWLOC_XMLFILE=$(pwd)/$(hostname).xml
         - !reference ['.build-core', 'script']
-        - cd $FLUX_BUILD_DIR
-        - make -j 32 check
+        - cd ${CORE_BUILD_DIR}
+        - make -j $(nproc) check
 
 .test-core-mpi:
     extends: .lc-variables
@@ -46,7 +46,7 @@ default:
         - export MPI_TESTS_DIRECTORY=$(pwd)/mpi
         - export FTC_DIRECTORY=$(pwd)
         - !reference ['.build-core', 'script']
-        - flux run -N2 $FLUX_BUILD_DIR/src/cmd/flux start $MPI_TESTS_DIRECTORY/outer_script.sh
+        - flux run -N2 $CORE_BUILD_DIR/src/cmd/flux start $MPI_TESTS_DIRECTORY/outer_script.sh
 
 ## Job Specifications
 corona-core-test:

--- a/.gitlab/builds.gitlab-ci.yml
+++ b/.gitlab/builds.gitlab-ci.yml
@@ -12,8 +12,13 @@
   script:
     - git clone https://github.com/flux-framework/flux-core
     - cd flux-core
-    - export FLUX_BUILD_DIR=$(pwd)
     - ./autogen.sh
-    - ./configure
-    - make -j 32
-    - cd ..
+    - mkdir build
+    - cd build
+    - mkdir install
+    - ../configure --prefix=$(pwd)/install
+    - make -j $(nproc)
+    - make -j $(nproc) install
+    - export CORE_BUILD_DIR=$(pwd)
+    - export CORE_INSTALL_PREFIX=$(pwd)/install
+    

--- a/.gitlab/machines.gitlab-ci.yml
+++ b/.gitlab/machines.gitlab-ci.yml
@@ -31,7 +31,7 @@
         - batch
     variables:
         HWLOC_COMPONENTS: "x86"
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pdebug"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pci"
 
 .quartz:
     tags:


### PR DESCRIPTION
We need a way of testing a side-installed flux-pmix along with a side-installed flux-core. This will enable us to test the LC provided versions of OpenMPI, particularly v5.0+ which will require flux-pmix.

This includes some refactoring of the way we build flux-core (`make install` to get the pkgconfig files) and a new test, corona-pmix-test.