### PR TITLE
mpi: add tioga compiler/MPI to tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,22 @@ default:
         - make -j $(nproc) check
         - make -j $(nproc) install
 
+.test-coral2:
+    extends: .lc-variables
+    variables:
+        PYTHON: "/usr/bin/python3"
+        debug: t
+        FLUX_TESTS_LOGFILE: t
+    script:
+        - cd ${CI_DIRECTORY}
+        - export PKG_CONFIG_PATH=${CORE_INSTALL_PREFIX}/lib/pkgconfig:$(pkg-config --variable pc_path pkg-config)
+        - git clone https://github.com/flux-framework/flux-coral2
+        - cd flux-coral2
+        - ./autogen.sh
+        - ./configure --prefix=${CORE_INSTALL_PREFIX}
+        - make -j $(nproc) check
+        - make -j $(nproc) install
+
 .test-core-mpi:
     extends: .lc-variables
     ## this will need coral2 XOR pmix depending on system (hopefully both eventually)
@@ -116,6 +132,22 @@ quartz-core-build:
         - .build-core
         - .quartz
     stage: build
+    
+tioga-coral2-test:
+    needs: ["tioga-core-build"]
+    extends:
+        - .test-coral2
+        - .tioga
+    stage: test
+
+tioga-mpi-test:
+    needs: ["tioga-core-build", "tioga-coral2-test"]
+    extends:
+        - .test-core-mpi
+        - .tioga
+    variables:
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "-N 2 -q pci"
+    stage: test
 
 quartz-core-test:
     needs: ["quartz-core-build"]

--- a/mpi/outer_script.sh
+++ b/mpi/outer_script.sh
@@ -18,12 +18,23 @@ abort
 version
 "
 
+tioga_COMPILERS="
+gcc
+cce
+"
+
+tioga_MPIS="
+cray-mpich
+"
+
 MPIS="${LCSCHEDCLUSTER}_MPIS"
 COMPILERS="${LCSCHEDCLUSTER}_COMPILERS"
 
 for mpi in ${!MPIS}; do
     for compiler in ${!COMPILERS}; do
-        if [[ $mpi == "openmpi" ]]; then
+        if [[ $mpi == "cray-mpich" ]]; then
+            EXTRA_FLUX_SUBMIT_OPTIONS="-o pmi=cray-pals" flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $mpi $compiler
+        elif [[ $mpi == "openmpi" ]]; then
             EXTRA_FLUX_SUBMIT_OPTIONS="-o pmi=pmix" flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $mpi $compiler
         else
             flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $mpi $compiler


### PR DESCRIPTION
Problem: we don't test the MPIs and compilers on Tioga.

Let's do that.

Turns out this is really easy to do, so why not go ahead and do it?