### PR TITLE
mpi: add testing for openmpi on corona

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ default:
     script:
         - export MPI_TESTS_DIRECTORY=$(pwd)/mpi
         - export FTC_DIRECTORY=$(pwd)
-        - flux run -N2 $CORE_BUILD_DIR/src/cmd/flux start $MPI_TESTS_DIRECTORY/outer_script.sh
+        - flux run -N2 $CORE_INSTALL_PREFIX/bin/flux start $MPI_TESTS_DIRECTORY/outer_script.sh
 
 corona-core-build:
     extends: 

--- a/.gitlab/builds.gitlab-ci.yml
+++ b/.gitlab/builds.gitlab-ci.yml
@@ -22,13 +22,13 @@
         - cd flux-core
         - ./autogen.sh
         - mkdir build
-        - cd build
         - mkdir install
-        - ../configure --prefix=$(pwd)/install
+        - cd build
+        - ../configure --prefix=${CI_DIRECTORY}/flux-core/install
         - make -j $(nproc)
         ## need to install to get pkgconfig files
         - export CORE_BUILD_DIR=$(pwd)
-        - export CORE_INSTALL_PREFIX=$(pwd)/install
+        - export CORE_INSTALL_PREFIX=${CI_DIRECTORY}/flux-core/install
         - cd $FTC_DIRECTORY
         - echo "CI_DIRECTORY=${CI_DIRECTORY}" >> build.env
         - echo "CORE_BUILD_DIR=${CORE_BUILD_DIR}" >> build.env

--- a/.gitlab/builds.gitlab-ci.yml
+++ b/.gitlab/builds.gitlab-ci.yml
@@ -27,6 +27,7 @@
         - ../configure --prefix=${CI_DIRECTORY}/flux-core/install
         - make -j $(nproc)
         ## need to install to get pkgconfig files
+        - make -j $(nproc) install
         - export CORE_BUILD_DIR=$(pwd)
         - export CORE_INSTALL_PREFIX=${CI_DIRECTORY}/flux-core/install
         - cd $FTC_DIRECTORY

--- a/mpi/inner_script.sh
+++ b/mpi/inner_script.sh
@@ -22,7 +22,7 @@ cp -r $MPI_TESTS_DIRECTORY/* $FTC_DIRECTORY/$NAME
 cd $FTC_DIRECTORY/$NAME || die "Could not find $FTC_DIRECTORY/$NAME"
 echo "Running with $1 compiler and $2 MPI"
 flux bulksubmit -n1 --watch mpicc -o {} {}.c ::: $TESTS || die "Compilation failure in tests"
-flux bulksubmit --watch -N $BATCH_NNODES -n $BATCH_NCORES --output=kvs ./{} ::: $TESTS
+flux bulksubmit --watch -N $BATCH_NNODES -n $BATCH_NCORES $EXTRA_FLUX_SUBMIT_OPTIONS --output=kvs ./{} ::: $TESTS
 RC=$?
 rm -rf $FTC_DIRECTORY/$NAME
 exit $RC

--- a/mpi/outer_script.sh
+++ b/mpi/outer_script.sh
@@ -10,6 +10,7 @@ intel-classic
 
 corona_MPIS="
 mvapich2
+openmpi
 "
 
 export TESTS="hello
@@ -22,7 +23,11 @@ COMPILERS="${LCSCHEDCLUSTER}_COMPILERS"
 
 for mpi in ${!MPIS}; do
     for compiler in ${!COMPILERS}; do
-        flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $mpi $compiler
+        if [[ $mpi == "openmpi" ]]; then
+            EXTRA_FLUX_SUBMIT_OPTIONS="-o pmi=pmix" flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $mpi $compiler
+        else
+            flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $mpi $compiler
+        fi 
     done
 done
 flux job wait --all


### PR DESCRIPTION
This builds off #10 and finally adds support for testing OpenMPI with flux-pmix on Corona. Currently, we only test openmpi v4, however, since the MPI and compilers are loaded via `module load` we'll get v5 as soon as it's the default on LC clusters.

This contains a [kinda embarassing] fix -- apparently I never actually added `make install` to #10, so pmix has been building and testing against the system `/usr/bin/flux` this whole time. Sorry I missed that...
