### PR TITLE
gitlab: add sched

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,23 @@ default:
         - make -j $(nproc) check
         - make -j $(nproc) install
 
+.test-sched:
+    extends: .lc-variables
+    variables:
+        PYTHON: "/usr/bin/python3"
+        debug: t
+        FLUX_TESTS_LOGFILE: t
+    script:
+        - cd ${CI_DIRECTORY}
+        - export PKG_CONFIG_PATH=${CORE_INSTALL_PREFIX}/lib/pkgconfig:$(pkg-config --variable pc_path pkg-config)
+        - git clone https://github.com/flux-framework/flux-sched
+        - cd flux-sched
+        - module load gcc 
+        - ${CORE_INSTALL_PREFIX}/bin/flux ./configure
+        - make -j $(nproc)
+        - make -j $(nproc) install
+        - ctest -j 16 -E "t5000-valgrind.t"
+
 .test-core-mpi:
     extends: .lc-variables
     ## this will need coral2 XOR pmix depending on system (hopefully both eventually)
@@ -98,6 +115,13 @@ corona-core-test:
     needs: ["corona-core-build"]
     extends: 
         - .test-core
+        - .corona
+    stage: test
+
+corona-sched-test:
+    needs: ["corona-core-build"]
+    extends:
+        - .test-sched
         - .corona
     stage: test
 
@@ -137,6 +161,13 @@ tioga-coral2-test:
     needs: ["tioga-core-build"]
     extends:
         - .test-coral2
+        - .tioga
+    stage: test
+
+tioga-sched-test:
+    needs: ["tioga-core-build"]
+    extends:
+        - .test-sched
         - .tioga
     stage: test
 


### PR DESCRIPTION
This is being put up as WIP because there are some failures in the testsuite when run under the gitlab runners:

```
(s=125,d=0) fluxci@corona82 /usr/WS1/fluxci/cibuilds/380819_tioga/flux-sched/t (master)$ cat test-suite.log | grep ERROR
# ERROR: 5
ERROR: t4005-match-unsat
ERROR: t4005-match-unsat.t - missing test plan
ERROR: t4005-match-unsat.t - exited with status 1
ERROR: t4008-match-jgf
ERROR: t4008-match-jgf.t - missing test plan
ERROR: t4008-match-jgf.t - exited with status 1
ERROR: t5000-valgrind
ERROR: t5000-valgrind.t - exited with status 1
```

Notably, the valgrind test is failing, even when I rerun it. I don't really see what the "missing test plan" is all about...