### PR TITLE
gitlab: drop HWLOC_COMPONENTS=x86

### DIFF
--- a/.gitlab/machines.gitlab-ci.yml
+++ b/.gitlab/machines.gitlab-ci.yml
@@ -14,7 +14,6 @@
         - corona
         - batch
     variables:
-        HWLOC_COMPONENTS: "x86"
         LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pdebug --setattr=bank=lc"
 
 .poodle:
@@ -22,7 +21,6 @@
         - poodle
         - batch
     variables:
-        HWLOC_COMPONENTS: "x86"
         LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -N 1 -p pdebug"
 
 .tioga:
@@ -30,7 +28,6 @@
         - tioga
         - batch
     variables:
-        HWLOC_COMPONENTS: "x86"
         LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pci"
 
 .quartz:
@@ -38,5 +35,4 @@
         - quartz
         - batch
     variables: 
-        HWLOC_COMPONENTS: "x86"
         LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -p pdebug"


### PR DESCRIPTION
Problem: per the hwloc(7) documentation for hwloc v2.3.0, the HWLOC_COMPONENTS environment variable, if used, will override the HWLOC_XMLFILE variable. According to the docs, "since this variable is the low-level and more generic way to select components, it takes precedence over environment variables for selecting components."

I don't believe we've actually hit this problem. But just in case, it seems advisable to drop the HWLOC_COMPONENTS variable in favor of using the xml file.