### PR TITLE
mpi: do node-exclusive scheduling for cray-pals PMI

### DIFF
--- a/mpi/outer_script.sh
+++ b/mpi/outer_script.sh
@@ -35,7 +35,7 @@ COMPILERS="${LCSCHEDCLUSTER}_COMPILERS"
 for mpi in ${!MPIS}; do
     for compiler in ${!COMPILERS}; do
         if [[ $mpi == "cray-mpich" ]]; then
-            EXTRA_FLUX_SUBMIT_OPTIONS="-o pmi=cray-pals" flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $compiler $mpi
+            EXTRA_FLUX_SUBMIT_OPTIONS="-o pmi=cray-pals" flux batch --exclusive -N2 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $compiler $mpi
         elif [[ $mpi == "openmpi"* ]]; then
             EXTRA_FLUX_SUBMIT_OPTIONS="-o pmi=pmix" flux batch -N2 -n4 --flags=waitable --output=kvs $MPI_TESTS_DIRECTORY/inner_script.sh $compiler $mpi
         else


### PR DESCRIPTION
Problem: as documented in the "CORAL2: Flux on Cray Shasta" page in the flux docs, two flux subinstances sharing the same nodes can fail due to overlapping port numbers. For some reason, ever since the vcpu test was added, this has been happening more often.

The solution is to do node-exclusive scheduling at the top level so the jobs run sequentially.