### PR TITLE
gitlab: move MPI jobs to pdebug queue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ tioga-mpi-test:
         - .test-core-mpi
         - .tioga
     variables:
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "-N 2 -q pci"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "-N 2 -q pdebug"
     stage: test
 
 quartz-core-test:


### PR DESCRIPTION
Recently, the pci queue has had nodes down for maintenance for days on end, resulting in our MPI jobs not being run. As a workaround for now, run them in the pdebug queue.