### PR TITLE
gitlab: add required tokens header

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,8 @@
 include:
   - local: '.gitlab/builds.gitlab-ci.yml'
   - local: '.gitlab/machines.gitlab-ci.yml'
+  - project: 'lc-templates/id_tokens'
+    file: 'id_tokens.yml'
 
 stages:
   - build


### PR DESCRIPTION
Problem: per [Technical Bulletin #568](https://hpc.llnl.gov/technical-bulletins/bulletin-568), LC GitLab jobs now require a header include in order to work.

Add that include statement to our main GitLab config file.

