### PR TITLE
RIP quartz

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,12 +153,6 @@ tioga-core-test:
         - .tioga
     stage: test
 
-quartz-core-build:
-    extends: 
-        - .build-core
-        - .quartz
-    stage: build
-    
 tioga-coral2-test:
     needs: ["tioga-core-build"]
     extends:
@@ -180,13 +174,6 @@ tioga-mpi-test:
         - .tioga
     variables:
         LLNL_FLUX_SCHEDULER_PARAMETERS: "-N 2 -q pdebug"
-    stage: test
-
-quartz-core-test:
-    needs: ["quartz-core-build"]
-    extends: 
-        - .test-core
-        - .quartz
     stage: test
 
 corona-pmix-test:

--- a/.gitlab/machines.gitlab-ci.yml
+++ b/.gitlab/machines.gitlab-ci.yml
@@ -30,9 +30,3 @@
     variables:
         LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pci"
 
-.quartz:
-    tags:
-        - quartz
-        - batch
-    variables: 
-        LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -p pdebug"


### PR DESCRIPTION
Problem: Quartz has been retired, so no jobs
will run there.

Remove it from the tests.