### PR TITLE
corona: upgrade compiler module

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ default:
         - export PKG_CONFIG_PATH=${CORE_INSTALL_PREFIX}/lib/pkgconfig:$(pkg-config --variable pc_path pkg-config)
         - git clone https://github.com/flux-framework/flux-sched
         - cd flux-sched
-        - module load gcc 
+        - module load gcc/12 
         - ${CORE_INSTALL_PREFIX}/bin/flux ./configure
         - make -j $(nproc)
         - make -j $(nproc) install


### PR DESCRIPTION
Problem: the default gcc loaded with lmod is
insufficient for building flux-sched.

Bump to gcc12.