### PR TITLE
update bank information, add poodle debugging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,23 @@ default:
         # Note: the above will not work with /usr/workspace, you must specify WS1 or WS2
 
 ## Job Specifications
+.test-core-poodle:
+    extends: .lc-variables
+    variables:
+        PYTHON: "/usr/bin/python3"
+        debug: t
+        FLUX_TESTS_LOGFILE: t
+    script:
+        - echo $CI_DIRECTORY
+        - cd ${CORE_BUILD_DIR}
+        - lstopo --of xml >$(hostname).xml
+        - export FLUX_HWLOC_XMLFILE=$(pwd)/$(hostname).xml
+        - make check
+        ## The following is teardown to make sure the xml file doesn't get reused
+        ## but maybe it's unnecessary. Subsequent tests will run under new shells...
+        - rm ${FLUX_HWLOC_XMLFILE}
+        - unset FLUX_HWLOC_XMLFILE
+
 .test-core:
     extends: .lc-variables
     variables:
@@ -136,7 +153,7 @@ poodle-core-build:
 poodle-core-test:
     needs: ["poodle-core-build"]
     extends: 
-        - .test-core
+        - .test-core-poodle
         - .poodle
     stage: test
 

--- a/.gitlab/machines.gitlab-ci.yml
+++ b/.gitlab/machines.gitlab-ci.yml
@@ -21,12 +21,12 @@
         - poodle
         - batch
     variables:
-        LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -N 1 -p pdebug"
+        LLNL_SLURM_SCHEDULER_PARAMETERS: "--exclusive -A lc -N 1 -p pdebug"
 
 .tioga:
     tags:
         - tioga
         - batch
     variables:
-        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pci"
+        LLNL_FLUX_SCHEDULER_PARAMETERS: "--exclusive -N 1 -q pci --setattr=bank=lc"
 


### PR DESCRIPTION
flux-test-collective recently woke up from a prolonged nap, and the testsuite runs well on all our LC machines except poodle. On poodle, the testsuite gets interrupted with `SIGKILL` 3 minutes and 24 seconds into running. Since the testsuite is running with `make -j $(nproc) check`, it's running 112 processes at once, making it difficult to tell exactly what's causing this. 

Serializing the testsuite might help reveal what the problem is.